### PR TITLE
Add scaling during decompression, grayscale output and decompressor parameters

### DIFF
--- a/src/decompress.rs
+++ b/src/decompress.rs
@@ -313,6 +313,14 @@ impl<'src> Decompress<'src> {
             format => Err(io::Error::new(io::ErrorKind::Other, format!("{:?}", format))),
         }
     }
+
+    /// Rescales the output image by `numerator / 8` during decompression.
+    /// `numerator` must be between 1 and 16. 
+    pub fn scale(&mut self, numerator: u8) {
+        assert!(1 <= numerator && numerator <= 16, "numerator must be between 1 and 16");
+        self.cinfo.scale_num = numerator.into();
+        self.cinfo.scale_denom = 8;
+    }
 }
 
 /// See `Decompress.image()`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ extern crate mozjpeg_sys as ffi;
 pub use compress::Compress;
 pub use compress::ScanMode;
 pub use decompress::{Decompress, NO_MARKERS, ALL_MARKERS};
-pub use decompress::Format;
+pub use decompress::{Format, DctMethod};
 pub use component::CompInfo;
 pub use component::CompInfoExt;
 pub use colorspace::ColorSpace;


### PR DESCRIPTION
This PR adds support for rescaling of the output image during JPEG decompression. This can be very useful to quickly generate a preview of a large JPEG file, as it is much faster than decompressing the file at full resolution and rescaling it afterwards.

The PR also adds support for gray-scale output as well as setting some decompressor parameters controlling the trade-off between speed and quality.
