### PR TITLE
Compress::write_scanlines fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ version = "0.8.10"
 libc = "0.2.45"
 mozjpeg-sys = { version = "0.9.0", default-features = false }
 rgb = "0.8.11"
-arrayvec = {version="0.4.8", features=["use_union"]}
 
 [features]
 default = ["nasm_simd"]

--- a/src/compress.rs
+++ b/src/compress.rs
@@ -128,7 +128,8 @@ impl Compress {
                 }
             }
         }
-        return true;
+
+        return self.cinfo.next_scanline < self.cinfo.image_height;
     }
 
     pub fn write_raw_data(&mut self, image_src: &[&[u8]]) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,6 @@
 #![allow(unused_imports)]
 
 extern crate libc;
-extern crate arrayvec;
 extern crate mozjpeg_sys as ffi;
 
 pub use compress::Compress;

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -28,12 +28,13 @@ fn color_jpeg() {
     comp.start_compress();
 
     let lines = vec![128; 32*32*3];
-    comp.write_scanlines(&lines[..]);
+    let result = comp.write_scanlines(&lines[..]);
 
     comp.finish_compress();
     let jpeg = comp.data_to_vec().unwrap();
 
     decompress_jpeg(&jpeg);
+    assert_eq!(result, false);
 }
 
 #[test]

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -23,11 +23,11 @@ fn color_jpeg() {
     let mut comp = mozjpeg::Compress::new(mozjpeg::ColorSpace::JCS_RGB);
 
     comp.set_scan_optimization_mode(mozjpeg::ScanMode::AllComponentsTogether);
-    comp.set_size(8, 8);
+    comp.set_size(32, 32);
     comp.set_mem_dest();
     comp.start_compress();
 
-    let lines = vec![128; 8*8*3];
+    let lines = vec![128; 32*32*3];
     comp.write_scanlines(&lines[..]);
 
     comp.finish_compress();


### PR DESCRIPTION
This fixes two issues in ` Compress::write_scanlines`. The function panicked when images with a height larger than `MAX_MCU_HEIGHT`. The issue is fixed by assigning the following batch of rows to the same array starting from index `0`, and passing the number of rows in the batch as a parameter to `jpeg_write_scanlines`.

The other issue emerges when writing progressive JPEG, which requires multiple scans. One way of achieving this is to call `write_scanlines` in a loop:
```rust
while compress.write_scanlines(&image) {
}
```
This resulted in a warning: 
```
Application transferred too many scanlines
```
This issue is fixed by returning `self.cinfo.next_scanline < self.cinfo.image_height`, so the loop finishes when the required amount of scans are completed.