### PR TITLE
Add decompression function with conversion to RGBA

### DIFF
--- a/src/decompress.rs
+++ b/src/decompress.rs
@@ -305,6 +305,12 @@ impl<'src> Decompress<'src> {
         return DecompressStarted::start_decompress(self);
     }
 
+    /// Start decompression with conversion to RGBA
+    pub fn rgba(mut self) -> io::Result<DecompressStarted<'src>> {
+        self.cinfo.out_color_space = ffi::J_COLOR_SPACE::JCS_EXT_RGBA;
+        return DecompressStarted::start_decompress(self);
+    }
+
     /// Start decompression with conversion to grayscale.
     pub fn grayscale(mut self) -> io::Result<DecompressStarted<'src>> {
         self.cinfo.out_color_space = ffi::J_COLOR_SPACE::JCS_GRAYSCALE;


### PR DESCRIPTION
Adds an `rgba` function similar to the existing `rgb` and `grayscale` functions. Doing this conversion at decompression time is faster than converting by hand at a later time.