### PR TITLE
Sister PR to the one in mozjpeg-sys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,13 @@ version = "0.8.14"
 
 [dependencies]
 libc = "0.2.49"
-mozjpeg-sys = { version = "0.10.1", default-features = false }
+mozjpeg-sys = { git = "https://github.com/gnzlbg/mozjpeg-sys", branch = "fub", default-features = false }
 rgb = "0.8.13"
 arrayvec = {version="0.4.10", features=["use_union"]}
+cpp = "0.5"
+
+[build-dependencies]
+cpp_build = "0.5"
 
 [features]
 default = ["nasm_simd", "mozjpeg-sys/unwinding"]

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    cpp_build::build("src/lib.rs");
+}

--- a/src/errormgr.rs
+++ b/src/errormgr.rs
@@ -5,28 +5,67 @@ pub use self::ffi::jpeg_error_mgr as ErrorMgr;
 use self::ffi::jpeg_common_struct;
 use ::std::mem;
 
+#[repr(C)]
+pub struct WrapperError {
+    buf: *const u8,
+    len: usize,
+    cap: usize,
+}
+
+cpp!{{
+    #include<stdexcept>
+
+    struct WrapperError {
+        char* buf;
+        uintptr_t len;
+        uintptr_t cap;
+    };
+
+    struct mozjpeg_rust_wrapper_exception: std::runtime_error {
+        mozjpeg_rust_wrapper_exception(): std::runtime_error("") {}
+        WrapperError error;
+    };
+
+    extern "C" WrapperError panic_error_exit_rust(void* cinfo);
+
+    extern "C" void panic_error_exit(void* cinfo) {
+        WrapperError error = panic_error_exit_rust(cinfo);
+        mozjpeg_rust_wrapper_exception e;
+        e.error = error;
+        throw e;
+    }
+}}
+
+#[no_mangle]
+pub extern "C" fn panic_error_exit_rust(cinfo: &mut jpeg_common_struct) -> WrapperError {
+    unsafe {
+        let err = cinfo.err.as_ref().unwrap();
+        let msg: String = match err.format_message {
+            Some(fmt) => {
+                let buffer = mem::zeroed();
+                fmt(cinfo, &buffer);
+                ::std::string::String::from_utf8_lossy(&buffer[..]).into_owned()
+            },
+            None => format!("code {}", err.msg_code),
+        };
+        let s = format!("libjpeg fatal error: {}", msg);
+        let e = WrapperError { buf: s.as_ptr(), len: s.len(), cap: s.capacity() };
+        std::mem::forget(s);
+        e
+    }
+}
+
 pub trait PanicingErrorMgr {
     fn new() -> ErrorMgr {
+        extern "C" {
+            fn panic_error_exit(cinfo: &mut jpeg_common_struct);
+        }
         unsafe{
+
             let mut err = mem::zeroed();
             ffi::jpeg_std_error(&mut err);
-            err.error_exit = Some(<ErrorMgr as PanicingErrorMgr>::panic_error_exit);
+            err.error_exit = Some(panic_error_exit);
             err
-        }
-    }
-
-    extern "C" fn panic_error_exit(cinfo: &mut jpeg_common_struct) {
-        unsafe {
-            let err = cinfo.err.as_ref().unwrap();
-            let msg: String = match err.format_message {
-                Some(fmt) => {
-                    let buffer = mem::zeroed();
-                    fmt(cinfo, &buffer);
-                    ::std::string::String::from_utf8_lossy(&buffer[..]).into_owned()
-                },
-                None => format!("code {}", err.msg_code),
-            };
-            panic!(format!("libjpeg fatal error: {}", msg));
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,9 @@ extern crate libc;
 extern crate arrayvec;
 extern crate mozjpeg_sys as ffi;
 
+#[macro_use]
+extern crate cpp;
+
 pub use compress::Compress;
 pub use compress::ScanMode;
 pub use decompress::{Decompress, NO_MARKERS, ALL_MARKERS};


### PR DESCRIPTION
Like in `mozjpeg-sys`, we could move 99% of this to a crate that does this automatically for you, but since there is only a single callback here, this might be ok.