### PR TITLE
Fix 'Compress::set_color_space' bug

### DIFF
--- a/src/compress.rs
+++ b/src/compress.rs
@@ -196,7 +196,6 @@ impl Compress {
     }
 
     pub fn set_color_space(&mut self, color_space: ColorSpace) {
-        self.cinfo.input_components = color_space.num_components() as c_int;
         unsafe {
             ffi::jpeg_set_colorspace(&mut self.cinfo, color_space);
         }


### PR DESCRIPTION
`Compress::set_color_space` used to set `mozjpeg_sys::jpeg_compress_struct::input_components`,
instead of `mozjpeg_sys::jpeg_compress_struct::num_components`.

I've removed this line completely, cause [MozJPEG's `jpeg_set_colorspace` sets this field itself][mozjpeg-jpeg_set_colorspace].

[mozjpeg-jpeg_set_colorspace]: https://github.com/mozilla/mozjpeg/blob/cfb713852354b139ca25a8c382de4166a67d41a1/jcparam.c#L592
