### PR TITLE
Add set_smoothing_factor fn

### DIFF
--- a/src/compress.rs
+++ b/src/compress.rs
@@ -274,8 +274,8 @@ impl Compress {
     }
 
     /// If 1-100 (non-zero), it will use MozJPEG's smoothing.
-    pub fn set_smoothing_factor(&mut self, smoothing_factor: c_int) {
-        self.cinfo.smoothing_factor = smoothing_factor;
+    pub fn set_smoothing_factor(&mut self, smoothing_factor: u8) {
+        self.cinfo.smoothing_factor = smoothing_factor as c_int;
     }
 
     /// Set to `false` to make files larger for no reason


### PR DESCRIPTION
I added the Compress::set_smoothing_factor function for MozJPEG's smooth function.

MozJPEG's argument reference:
https://github.com/mozilla/mozjpeg/blob/5552483db96d9c5c18ae60a7e3bff2be99d78247/usage.txt#L213-L215

MozJPEG's argument parser:
https://github.com/mozilla/mozjpeg/blob/afdcab16c5d706e55af50c93c09f6be7b4ca9288/cjpeg.c#L579-L589