### PR TITLE
Added in-buffer scanline decoding API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,15 +10,15 @@ license = "IJG"
 name = "mozjpeg"
 readme = "README.md"
 repository = "https://github.com/ImageOptim/mozjpeg-rust"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2018"
 
 [dependencies]
-libc = "0.2.98"
-mozjpeg-sys = { version = "1.0.0", default-features = false }
-rgb = { version = "0.8.27", features = ["as-bytes"] }
-arrayvec = "0.7.1"
-fallible_collections = "0.4.2"
+libc = "0.2"
+mozjpeg-sys = { version = "1.0", default-features = false }
+rgb = { version = "0.8", features = ["as-bytes"] }
+arrayvec = "0.7"
+fallible_collections = "0.4"
 
 [features]
 default = ["nasm_simd", "mozjpeg-sys/unwinding"]
@@ -26,7 +26,7 @@ nasm_simd = ["mozjpeg-sys/nasm_simd"]
 with_simd = ["mozjpeg-sys/with_simd"]
 
 [dev-dependencies]
-bytemuck = "1.7.0"
+bytemuck = "1.7"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]


### PR DESCRIPTION
Hi!

I needed this personally for a project, so I'm submitting a (draft) PR for this feature.

* Added `DecompressStarted::read_scanlines_into` to do in-buffer scanline decoding

I'm still a bit unsure on how sound my code is, but it does work on my machine™️ for hours on end (it's used in a webcam capture + tensorflow ML inference project).

Most of the diff is rustfmt doing its thing anyway. I'll make a cleanup pass before marking the PR as reviewable :)

Thanks!