### PR TITLE
Added pixel density getter and setter for compression and decompression

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = "1.71"
 
 [dependencies]
 libc = "0.2.150"
-mozjpeg-sys = { git = "https://github.com/kornelski/mozjpeg-sys.git", branch = "main", default-features = false, features = ["unwinding"] }
+mozjpeg-sys = { version = "2.1.0", default-features = false, features = ["unwinding"] }
 rgb = { version = "0.8.34", features = ["as-bytes"] }
 arrayvec = "0.7.4"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = "1.71"
 
 [dependencies]
 libc = "0.2.150"
-mozjpeg-sys = { version = "2.0.6", default-features = false, features = ["unwinding"] }
+mozjpeg-sys = { git = "https://github.com/kornelski/mozjpeg-sys.git", branch = "main", default-features = false, features = ["unwinding"] }
 rgb = { version = "0.8.34", features = ["as-bytes"] }
 arrayvec = "0.7.4"
 

--- a/src/compress.rs
+++ b/src/compress.rs
@@ -332,7 +332,7 @@ impl Compress {
         self.cinfo.input_gamma = gamma;
     }
 
-    /// Sets pixel density of an image written in JFIF APP0 segment.
+    /// Sets pixel density of an image
     pub fn set_pixel_density(&mut self, density: PixelDensity) {
         self.cinfo.density_unit = density.unit as u8;
         self.cinfo.X_density = density.x;

--- a/src/compress.rs
+++ b/src/compress.rs
@@ -332,7 +332,13 @@ impl Compress {
         self.cinfo.input_gamma = gamma;
     }
 
-    /// Sets pixel density of an image
+
+    /// Sets pixel density of an image in the JFIF APP0 segment[^note].
+    /// If this method is not called, the resulting JPEG will have a default
+    /// pixel aspect ratio of 1x1.
+    ///
+    /// [^note]: This method is not related to EXIF-based intrinsic image sizing,
+    /// and does not affect rendering in browsers.
     pub fn set_pixel_density(&mut self, density: PixelDensity) {
         self.cinfo.density_unit = density.unit as u8;
         self.cinfo.X_density = density.x;

--- a/src/compress.rs
+++ b/src/compress.rs
@@ -1,4 +1,4 @@
-use crate::colorspace::ColorSpace;
+use crate::{colorspace::ColorSpace, PixelDensity};
 use crate::colorspace::ColorSpaceExt;
 use crate::component::CompInfo;
 use crate::component::CompInfoExt;
@@ -330,6 +330,13 @@ impl Compress {
     #[deprecated(note = "it doesn't do anything")]
     pub fn set_gamma(&mut self, gamma: f64) {
         self.cinfo.input_gamma = gamma;
+    }
+
+    /// Sets pixel density of an image written in JFIF APP0 segment.
+    pub fn set_pixel_density(&mut self, density: PixelDensity) {
+        self.cinfo.density_unit = density.unit as u8;
+        self.cinfo.X_density = density.x;
+        self.cinfo.Y_density = density.y;
     }
 
     /// If true, it will use MozJPEG's scan optimization. Makes progressive image files smaller.

--- a/src/decompress.rs
+++ b/src/decompress.rs
@@ -1,5 +1,5 @@
 //! See the `Decompress` struct instead. You don't need to use this module directly.
-use crate::colorspace::ColorSpace;
+use crate::{colorspace::ColorSpace, PixelDensity};
 use crate::colorspace::ColorSpaceExt;
 use crate::component::CompInfo;
 use crate::component::CompInfoExt;
@@ -287,6 +287,24 @@ impl<R> Decompress<R> {
     pub fn gamma(&self) -> f64 {
         self.cinfo.output_gamma
     }
+
+    /// Get pixel density of an image from the JFIF APP0 segment.
+    /// Returns None in case of an invalid density unit.
+    #[inline]
+    #[must_use]
+    pub fn pixel_density(&mut self) -> Option<PixelDensity> {
+        Some(PixelDensity {
+            unit: match self.cinfo.density_unit {
+                0 => crate::PixelDensityUnit::PixelAspectRatio,
+                1 => crate::PixelDensityUnit::Inches,
+                2 => crate::PixelDensityUnit::Centimeters,
+                _ => return None,
+            },
+            x: self.cinfo.X_density,
+            y: self.cinfo.Y_density,
+        })
+    }
+
 
     /// Markers are available only if you enable them via `with_markers()`
     #[inline]

--- a/src/density.rs
+++ b/src/density.rs
@@ -1,0 +1,25 @@
+#[derive(Copy, Clone)]
+pub enum PixelDensityUnit {
+    /// No units
+    PixelAspectRatio = 0,
+    /// Pixels per inch
+    Inches = 1,
+    /// Pixels per centimeter
+    Centimeters = 2,
+}
+
+pub struct PixelDensity {
+    pub unit: PixelDensityUnit,
+    pub x: u16,
+    pub y: u16,
+}
+
+impl Default for PixelDensity {
+    fn default() -> Self {
+        PixelDensity {
+            unit: PixelDensityUnit::PixelAspectRatio,
+            x: 1,
+            y: 1,
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub use crate::compress::Compress;
 pub use crate::compress::ScanMode;
 pub use crate::decompress::{DctMethod, Format};
 pub use crate::decompress::{Decompress, ALL_MARKERS, NO_MARKERS};
+pub use crate::density::{PixelDensity, PixelDensityUnit};
 use crate::ffi::boolean;
 use crate::ffi::jpeg_common_struct;
 use crate::ffi::jpeg_compress_struct;
@@ -33,6 +34,7 @@ mod colorspace;
 mod component;
 mod compress;
 pub mod decompress;
+mod density;
 mod errormgr;
 mod marker;
 /// Quantization table presets from MozJPEG


### PR DESCRIPTION
Hi, this is a follow-up to https://github.com/kornelski/mozjpeg-sys/pull/37. 

This provides a better API than potentially exposing corresponding `cinfo` fields.
The structs are similar to the ones in the `image` crate (https://docs.rs/image/latest/image/codecs/jpeg/struct.PixelDensity.html).

The getter is a bit questionable in the way it handles invalid density units, but I wasn't sure of the best approach here.

