### PR TITLE
fix: preserve smoothing_factor across jpeg_set_defaults calls

### DIFF
--- a/src/compress.rs
+++ b/src/compress.rs
@@ -389,20 +389,24 @@ impl Compress {
 
     /// One scan for all components looks best. Other options may flash grayscale or green images.
     pub fn set_scan_optimization_mode(&mut self, mode: ScanMode) {
+        let smoothing_factor = self.cinfo.smoothing_factor;
         unsafe {
             ffi::jpeg_c_set_int_param(&mut self.cinfo, J_INT_PARAM::JINT_DC_SCAN_OPT_MODE, mode as c_int);
             ffi::jpeg_set_defaults(&mut self.cinfo);
         }
+        self.cinfo.smoothing_factor = smoothing_factor;
     }
 
     /// Reset to libjpeg v6 settings
     ///
     /// It gives files identical with libjpeg-turbo
     pub fn set_fastest_defaults(&mut self) {
+        let smoothing_factor = self.cinfo.smoothing_factor;
         unsafe {
             ffi::jpeg_c_set_int_param(&mut self.cinfo, J_INT_PARAM::JINT_COMPRESS_PROFILE, ffi::JINT_COMPRESS_PROFILE_VALUE::JCP_FASTEST as c_int);
             ffi::jpeg_set_defaults(&mut self.cinfo);
         }
+        self.cinfo.smoothing_factor = smoothing_factor;
     }
 
     /// Advanced. See `raw_data_in` in libjpeg docs.

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -167,3 +167,65 @@ fn decode_jpeg(buffer: &[u8]) -> (usize, usize, Vec<[u8; 3]>) {
 
     (width, height, image)
 }
+
+/// Test that smoothing_factor is preserved when calling set_scan_optimization_mode
+/// Regression test for https://github.com/ImageOptim/mozjpeg-rust/issues/45
+#[test]
+fn smoothing_factor_preserved() {
+    // Generate a dither-like pattern that benefits from smoothing
+    let size = 64;
+    let mut data = Vec::with_capacity(size * size * 3);
+    for y in 0..size {
+        for x in 0..size {
+            let v = if ((x / 2) + (y / 2)) % 2 == 0 { 80u8 } else { 176u8 };
+            data.push(v);
+            data.push(v);
+            data.push(v);
+        }
+    }
+
+    // Compress without smoothing
+    let size_no_smooth = {
+        let mut comp = mozjpeg::Compress::new(mozjpeg::ColorSpace::JCS_RGB);
+        comp.set_size(size, size);
+        comp.set_quality(80.0);
+        comp.set_smoothing_factor(0);
+        comp.set_scan_optimization_mode(mozjpeg::ScanMode::Auto);
+        let mut comp = comp.start_compress(Vec::new()).unwrap();
+        comp.write_scanlines(&data).unwrap();
+        comp.finish().unwrap().len()
+    };
+
+    // Compress with smoothing set BEFORE set_scan_optimization_mode
+    let size_smooth_before = {
+        let mut comp = mozjpeg::Compress::new(mozjpeg::ColorSpace::JCS_RGB);
+        comp.set_size(size, size);
+        comp.set_quality(80.0);
+        comp.set_smoothing_factor(50);
+        comp.set_scan_optimization_mode(mozjpeg::ScanMode::Auto);
+        let mut comp = comp.start_compress(Vec::new()).unwrap();
+        comp.write_scanlines(&data).unwrap();
+        comp.finish().unwrap().len()
+    };
+
+    // Compress with smoothing set AFTER set_scan_optimization_mode
+    let size_smooth_after = {
+        let mut comp = mozjpeg::Compress::new(mozjpeg::ColorSpace::JCS_RGB);
+        comp.set_size(size, size);
+        comp.set_quality(80.0);
+        comp.set_scan_optimization_mode(mozjpeg::ScanMode::Auto);
+        comp.set_smoothing_factor(50);
+        let mut comp = comp.start_compress(Vec::new()).unwrap();
+        comp.write_scanlines(&data).unwrap();
+        comp.finish().unwrap().len()
+    };
+
+    // Smoothing should reduce file size for high-frequency content
+    assert!(size_smooth_after < size_no_smooth,
+        "smoothing should reduce size: {} < {}", size_smooth_after, size_no_smooth);
+
+    // Both orderings should produce the same result (this was the bug)
+    assert_eq!(size_smooth_before, size_smooth_after,
+        "smoothing_factor should work regardless of call order: {} != {}",
+        size_smooth_before, size_smooth_after);
+}


### PR DESCRIPTION
## Summary

`set_scan_optimization_mode()` and `set_fastest_defaults()` call `jpeg_set_defaults()` which resets all compression parameters, including `smoothing_factor`. This caused `set_smoothing_factor()` to have no effect if called before these methods.

## Fix

Save and restore `smoothing_factor` around the `jpeg_set_defaults()` calls.

## Test

Added regression test that verifies:
1. Smoothing reduces file size for high-frequency content
2. `set_smoothing_factor()` works regardless of whether it's called before or after `set_scan_optimization_mode()`

Fixes #45