### PR TITLE
feat: expose force_baseline as set_quality_force_8bit

### DIFF
--- a/src/compress.rs
+++ b/src/compress.rs
@@ -411,23 +411,79 @@ impl Compress {
     }
 
     /// Set image quality. Values 60-80 are recommended.
+    ///
+    /// Quantization table values are not clamped to the 8-bit range, so at low
+    /// quality settings (below ~50) some values may exceed 255 and produce
+    /// 16-bit DQT markers.
+    ///
+    /// Use [`set_quality_force_8bit`](Self::set_quality_force_8bit) to control
+    /// whether values are clamped to 1-255.
     pub fn set_quality(&mut self, quality: f32) {
         unsafe {
             ffi::jpeg_set_quality(&mut self.cinfo, quality as c_int, boolean::from(false));
         }
     }
 
+    /// Set image quality with control over 8-bit quantization table clamping.
+    ///
+    /// When `force_8bit_quantization` is `true`, quantization table values are
+    /// clamped to 1-255 (8-bit DQT precision). When `false`, values can go up to
+    /// 32767 (16-bit DQT precision).
+    ///
+    /// This only affects quantization table value range. It does NOT disable
+    /// progressive encoding, change the SOF marker type, or affect any other
+    /// encoding parameters.
+    ///
+    /// Corresponds to the `force_baseline` parameter in libjpeg's `jpeg_set_quality()`.
+    pub fn set_quality_force_8bit(&mut self, quality: f32, force_8bit_quantization: bool) {
+        unsafe {
+            ffi::jpeg_set_quality(&mut self.cinfo, quality as c_int, boolean::from(force_8bit_quantization));
+        }
+    }
+
     /// Instead of quality setting, use a specific quantization table.
+    ///
+    /// Table values are clamped to 1-255 (8-bit DQT precision).
+    /// Use [`set_luma_qtable_force_8bit`](Self::set_luma_qtable_force_8bit) for explicit control.
     pub fn set_luma_qtable(&mut self, qtable: &QTable) {
         unsafe {
             ffi::jpeg_add_quant_table(&mut self.cinfo, 0, qtable.as_ptr(), 100, 1);
         }
     }
 
+    /// Instead of quality setting, use a specific quantization table with
+    /// control over 8-bit clamping.
+    ///
+    /// When `force_8bit_quantization` is `true`, table values are clamped to 1-255.
+    /// When `false`, values can go up to 32767.
+    ///
+    /// Corresponds to the `force_baseline` parameter in libjpeg's `jpeg_add_quant_table()`.
+    pub fn set_luma_qtable_force_8bit(&mut self, qtable: &QTable, force_8bit_quantization: bool) {
+        unsafe {
+            ffi::jpeg_add_quant_table(&mut self.cinfo, 0, qtable.as_ptr(), 100, boolean::from(force_8bit_quantization) as c_int);
+        }
+    }
+
     /// Instead of quality setting, use a specific quantization table for color.
+    ///
+    /// Table values are clamped to 1-255 (8-bit DQT precision).
+    /// Use [`set_chroma_qtable_force_8bit`](Self::set_chroma_qtable_force_8bit) for explicit control.
     pub fn set_chroma_qtable(&mut self, qtable: &QTable) {
         unsafe {
             ffi::jpeg_add_quant_table(&mut self.cinfo, 1, qtable.as_ptr(), 100, 1);
+        }
+    }
+
+    /// Instead of quality setting, use a specific quantization table for color
+    /// with control over 8-bit clamping.
+    ///
+    /// When `force_8bit_quantization` is `true`, table values are clamped to 1-255.
+    /// When `false`, values can go up to 32767.
+    ///
+    /// Corresponds to the `force_baseline` parameter in libjpeg's `jpeg_add_quant_table()`.
+    pub fn set_chroma_qtable_force_8bit(&mut self, qtable: &QTable, force_8bit_quantization: bool) {
+        unsafe {
+            ffi::jpeg_add_quant_table(&mut self.cinfo, 1, qtable.as_ptr(), 100, boolean::from(force_8bit_quantization) as c_int);
         }
     }
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -154,6 +154,89 @@ fn encode_jpeg_with_icc_profile((width, height, data): (usize, usize, Vec<[u8; 3
     encoder.finish().unwrap()
 }
 
+// ============================================================================
+// force_8bit_quantization tests
+// ============================================================================
+
+#[test]
+fn force_8bit_false_matches_set_quality() {
+    // set_quality_force_8bit(q, false) must produce identical output to set_quality(q)
+    for &quality in &[10.0, 50.0, 85.0, 95.0] {
+        let size = 32;
+        let pixels = vec![128u8; size * size * 3];
+
+        // Legacy set_quality (hardcodes force_baseline=false)
+        let mut comp = Compress::new(ColorSpace::JCS_RGB);
+        comp.set_size(size, size);
+        comp.set_quality(quality);
+        let mut started = comp.start_compress(Vec::new()).unwrap();
+        started.write_scanlines(&pixels).unwrap();
+        let jpeg_legacy = started.finish().unwrap();
+
+        // New method with force_8bit=false
+        let mut comp = Compress::new(ColorSpace::JCS_RGB);
+        comp.set_size(size, size);
+        comp.set_quality_force_8bit(quality, false);
+        let mut started = comp.start_compress(Vec::new()).unwrap();
+        started.write_scanlines(&pixels).unwrap();
+        let jpeg_new = started.finish().unwrap();
+
+        assert_eq!(jpeg_legacy, jpeg_new,
+            "set_quality_force_8bit(q, false) should match set_quality(q) at quality {quality}");
+    }
+}
+
+#[test]
+fn force_8bit_true_clamps_at_low_quality() {
+    // At low quality, quantization values exceed 255. Clamping produces different output.
+    let size = 32;
+    let pixels = vec![128u8; size * size * 3];
+
+    let mut comp = Compress::new(ColorSpace::JCS_RGB);
+    comp.set_size(size, size);
+    comp.set_quality_force_8bit(10.0, false);
+    let mut started = comp.start_compress(Vec::new()).unwrap();
+    started.write_scanlines(&pixels).unwrap();
+    let jpeg_unclamped = started.finish().unwrap();
+
+    let mut comp = Compress::new(ColorSpace::JCS_RGB);
+    comp.set_size(size, size);
+    comp.set_quality_force_8bit(10.0, true);
+    let mut started = comp.start_compress(Vec::new()).unwrap();
+    started.write_scanlines(&pixels).unwrap();
+    let jpeg_clamped = started.finish().unwrap();
+
+    assert_ne!(jpeg_unclamped, jpeg_clamped,
+        "force_8bit at quality 10 should produce different output (16-bit vs 8-bit DQT)");
+    // Clamped version is slightly smaller (8-bit DQT markers vs 16-bit)
+    assert!(jpeg_clamped.len() < jpeg_unclamped.len(),
+        "8-bit DQT should be smaller than 16-bit DQT");
+}
+
+#[test]
+fn force_8bit_no_effect_at_high_quality() {
+    // At high quality, all quantization values are <= 255 anyway.
+    let size = 32;
+    let pixels = vec![128u8; size * size * 3];
+
+    let mut comp = Compress::new(ColorSpace::JCS_RGB);
+    comp.set_size(size, size);
+    comp.set_quality_force_8bit(85.0, false);
+    let mut started = comp.start_compress(Vec::new()).unwrap();
+    started.write_scanlines(&pixels).unwrap();
+    let jpeg_unclamped = started.finish().unwrap();
+
+    let mut comp = Compress::new(ColorSpace::JCS_RGB);
+    comp.set_size(size, size);
+    comp.set_quality_force_8bit(85.0, true);
+    let mut started = comp.start_compress(Vec::new()).unwrap();
+    started.write_scanlines(&pixels).unwrap();
+    let jpeg_clamped = started.finish().unwrap();
+
+    assert_eq!(jpeg_unclamped, jpeg_clamped,
+        "force_8bit should have no effect at quality 85 (all values already <= 255)");
+}
+
 fn decode_jpeg(buffer: &[u8]) -> (usize, usize, Vec<[u8; 3]>) {
     let mut decoder = match mozjpeg::Decompress::new_mem(buffer).unwrap().image().unwrap() {
         mozjpeg::decompress::Format::RGB(d) => d,


### PR DESCRIPTION
## Summary

Fixes #3 — adds the ability to clamp quantization table values to the 8-bit range (1-255) for decoder compatibility.

- `set_quality_force_8bit(quality, force_8bit)` — like `set_quality()` but with explicit control over the `force_baseline` parameter
- `set_luma_qtable_force_8bit(qtable, force_8bit)` — like `set_luma_qtable()` with explicit clamping control
- `set_chroma_qtable_force_8bit(qtable, force_8bit)` — like `set_chroma_qtable()` with explicit clamping control

No breaking changes — existing methods are unchanged.

## Context

`set_quality()` hardcodes `force_baseline=FALSE`. At low quality settings (below ~50), mozjpeg's quantization tables produce values exceeding 255, resulting in 16-bit DQT markers. Some decoders (notably older macOS/iOS optimized JPEG decoders) can't handle 16-bit DQT entries.

The `force_baseline` parameter in libjpeg only clamps quantization table values — it does not disable progressive encoding or change any other encoding behavior.

## Test plan

- [ ] Verify new methods compile and are callable
- [ ] Verify `set_quality_force_8bit(q, false)` produces identical output to `set_quality(q)`
- [ ] Verify `set_quality_force_8bit(10.0, true)` produces different (smaller) output at low quality